### PR TITLE
Add LinkedIn style profile page

### DIFF
--- a/linkedin.css
+++ b/linkedin.css
@@ -1,0 +1,82 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #f3f2ef;
+}
+
+header {
+    background-color: #283e4a;
+    color: white;
+    padding: 1rem;
+}
+
+.profile {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    background-color: white;
+    padding: 2rem;
+    margin: 1rem auto;
+    max-width: 900px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.profile img {
+    width: 150px;
+    height: 150px;
+    border-radius: 50%;
+    margin-right: 2rem;
+}
+
+.profile-details h1 {
+    margin: 0;
+    font-size: 2rem;
+}
+
+.profile-details p.title {
+    color: #666;
+    font-size: 1.1rem;
+}
+
+.section {
+    background-color: white;
+    max-width: 900px;
+    margin: 1rem auto;
+    padding: 1.5rem;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.section h2 {
+    border-bottom: 1px solid #ddd;
+    padding-bottom: 0.5rem;
+    margin-bottom: 1rem;
+    color: #283e4a;
+}
+
+.section ul {
+    list-style: disc inside;
+}
+
+.contact a {
+    color: #0073b1;
+    text-decoration: none;
+}
+
+.download-btn {
+    display: inline-block;
+    margin-top: 0.5rem;
+    padding: 0.5rem 1rem;
+    background-color: #0073b1;
+    color: white;
+    text-decoration: none;
+    border-radius: 4px;
+}
+
+footer {
+    text-align: center;
+    padding: 1rem;
+    background-color: #283e4a;
+    color: white;
+    margin-top: 2rem;
+}

--- a/linkedin.html
+++ b/linkedin.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Ioannis Tzachristas - LinkedIn Style Profile</title>
+<link rel="stylesheet" href="linkedin.css">
+</head>
+<body>
+<header>
+  <h1>Ioannis Tzachristas</h1>
+</header>
+<section class="profile">
+  <img src="AAYQBAT4AAgAAQAAAAAAAD12CZAJz9QNRTuXQ1VzESMEKw.png" alt="Ioannis Tzachristas">
+  <div class="profile-details">
+    <h1>Ioannis Tzachristas</h1>
+    <p class="title">PhD Candidate at Technical University of Munich &amp; Huawei Munich Research Center</p>
+    <p class="contact">
+      Riesstrasse 25, 80992 Munich, Bavaria, Germany<br>
+      Mobile: +30 6980228092 &nbsp;|&nbsp; +49 1707410323<br>
+      Email: <a href="mailto:jtzach@gmail.com">jtzach@gmail.com</a> |
+      <a href="mailto:ioannis.tzachristas@huawei.com">ioannis.tzachristas@huawei.com</a> |
+      <a href="mailto:ioannis.tzachristas@tum.de">ioannis.tzachristas@tum.de</a><br>
+      ORCID: <a href="https://orcid.org/0009-0007-0523-2889">0009-0007-0523-2889</a> |
+      <a href="https://scholar.google.com/citations?user=7p_28KEAAAAJ&amp;hl=el&amp;oi=ao">Google Scholar</a> |
+      <a href="https://arxiv.org/search/cs?searchtype=author&amp;query=Tzachristas%2C+I">arXiv</a>
+    </p>
+    <a class="download-btn" href="CV-IOANNIS TZACHRISTAS-Feb2025.pdf" download>Download CV (PDF)</a>
+    <a class="download-btn" href="CV-IOANNIS TZACHRISTAS-Feb2025.docx" download>Download CV (DOCX)</a>
+  </div>
+</section>
+
+<section class="section">
+  <h2>Education</h2>
+  <ul>
+    <li><strong>PhD in Transportation Systems Engineering</strong>, Technical University of Munich (09/2024&nbsp;&ndash;&nbsp;present) &ndash; Topic: Privilege Management of LLM-based AI-agents and Applications in Transportation Systems. Supervised by Prof. Constantinos Antoniou, co-supervised by Dr. Aifen Sui (Huawei Munich Research Center).</li>
+    <li><strong>M.Sc. &amp; MEng. in Electrical and Computer Engineering</strong>, National Technical University of Athens (09/2019&nbsp;&ndash;&nbsp;07/2024). GPA 9.02/10 (Excellent), Thesis grade 10/10. Member of NTUA Microprocessors &amp; Digital Systems Laboratory.</li>
+    <li><strong>General Lyceum of Zosimaia School</strong>, Ioannina, Greece (09/2016&nbsp;&ndash;&nbsp;06/2019). GPA 20/20 (Excellent).</li>
+  </ul>
+</section>
+
+<section class="section">
+  <h2>Work Experience</h2>
+  <ul>
+    <li><strong>Fixed Term PhD Contract</strong>, Huawei Munich Research Center &ndash; Trustworthy Technology and Engineering Laboratory (09/2024&nbsp;&ndash;&nbsp;present). Identity &amp; Access Management group.</li>
+    <li><strong>Master Student Contract</strong>, Huawei Munich Research Center (01/2024&nbsp;&ndash;&nbsp;08/2024). Thesis: Creating an LLM-based AI-agent: A high-level methodology towards enhancing LLMs with APIs.</li>
+    <li><strong>Internship Contract</strong>, Huawei Munich Research Center (07/2023&nbsp;&ndash;&nbsp;01/2024). Projects on Formal Methods for Security.</li>
+  </ul>
+</section>
+
+<section class="section">
+  <h2>Awards &amp; Academic Activities</h2>
+  <ul>
+    <li>Gold Medal and unique problem 8 solver at the 28th International Mathematics Competition for University Students (IMC&nbsp;2021).</li>
+    <li>Bronze Medal at the 15th SEEMOUS&nbsp;2021.</li>
+    <li>Gold Medal at the 4th Open Mathematical Olympiad for University Students&nbsp;2021 (IUHD).</li>
+    <li>Honorable Mention at the 27th IMC&nbsp;2020.</li>
+    <li>Gold Medal and 1st Place at the 3rd Open Mathematical Olympiad for University Students&nbsp;2020 (IUHD).</li>
+    <li>Bronze Medal at the 14th SEEMOUS&nbsp;2020.</li>
+    <li>3rd Greek Place at the Mediterranean Mathematical Competition&nbsp;2019.</li>
+    <li>Bronze Medal at the 36th National Mathematical Olympiad&nbsp;2019.</li>
+    <li>Team leader at the 4th Open Mathematical Olympiad for University Students&nbsp;2021.</li>
+    <li>Organising committee member at the 13th Mathematical Summer School&nbsp;2019 of the Hellenic Mathematical Society.</li>
+    <li>Invigilator for the Hellenic Mathematical Society at the "Thales" competition&nbsp;2019.</li>
+    <li>Elsevier Certificate of Reviewing for Transportation Research Part A: Policy and Practice.</li>
+  </ul>
+</section>
+
+<section class="section">
+  <h2>Skills</h2>
+  <ul>
+    <li><strong>Programming &amp; Tools:</strong> C++, Python, MATLAB, TinkerCad, Arduino, LTspice, GNU Octave, PicoScope, MathWorks, GeoGebra, MS Office, NuSMV, SPIN, Maude, Z3-Prover.</li>
+    <li><strong>Languages:</strong> English (Michigan ECCE&nbsp;&ndash;&nbsp;1000/1000 in Speaking), German (B1 Staatszertifikat), Greek.</li>
+  </ul>
+</section>
+
+<section class="section">
+  <h2>Scientific Interests</h2>
+  <ul>
+    <li>Discrete Mathematics (Combinatorics, Algorithms, Graph Theory, Number Theory, Automata Theory)</li>
+    <li>Cyber Security and Information Security</li>
+    <li>Formal Methods, Formal Verification &amp; Model Checking</li>
+    <li>Geometry</li>
+  </ul>
+</section>
+
+<section class="section">
+  <h2>Hobbies</h2>
+  <ul>
+    <li>Piano and Music Theory &amp; Harmony education at the Municipal Conservatory of Ioannina.</li>
+    <li>Participation in concerts as a pianist and in the NTUA chorus.</li>
+    <li>Chess player, participant in local and national tournaments with several medals.</li>
+    <li>Latin dancing, Greek traditional dancing, and sports activities such as running, rowing, and basketball.</li>
+  </ul>
+</section>
+
+<footer>
+  &copy; 2024 Ioannis Tzachristas
+</footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create LinkedIn-like HTML profile for Ioannis Tzachristas
- add CSS styling

## Testing
- `grep -n "Ioannis" -n linkedin.html | head`
- `wc -l linkedin.css`


------
https://chatgpt.com/codex/tasks/task_e_684170ea41c083338725d48a5d157d6d